### PR TITLE
Fix bug where ships from previous game in first level

### DIFF
--- a/src/iridisalpha.asm
+++ b/src/iridisalpha.asm
@@ -7393,6 +7393,7 @@ KeyWasPressed
         ; countdown so that it exits it nearly immediately.
         LDY #$02
         STY attractModeCountdown
+        RTS
 b787C   LDY levelRestartInProgress
         BNE ReturnEarlyFromKeyboardCheck
         LDY gilbyHasJustDied

--- a/src/iridisalpha.asm
+++ b/src/iridisalpha.asm
@@ -1006,6 +1006,7 @@ p4003   LDA #<MainControlLoopInterruptHandler
         LDA #$0F
         STA $D418    ;Select Filter Mode and Volume
         JSR ClearPlanetTextureCharsets
+        JSR InitializeActiveShipArray
         JMP PrepareToLaunchIridisAlpha
 
 ;------------------------------------------------------------------
@@ -8889,5 +8890,21 @@ pE800   SEI
         STA $DD0E    ;CIA2: CIA Control Register A
         CLI
         JMP $0835
+
+;------------------------------------------------------------------
+; InitializeActiveShipArray
+;------------------------------------------------------------------
+InitializeActiveShipArray
+        LDX #$00
+InitializeActiveShipLoop
+        LDA <planet1Level1Data
+        STA activeShipsWaveDataLoPtrArray,X
+        LDA >planet1Level1Data
+        STA activeShipsWaveDataHiPtrArray,X
+        INX
+        CPX #$10
+        BNE InitializeActiveShipLoop
+        RTS
+
 
 ; vim: tabstop=2 shiftwidth=2 expandtab


### PR DESCRIPTION
If you play a game and die, then start a new game, the first few ships are left over from the wave you died playing. Fix this by initializing the wave data when we start a new game.

Fixes #2 