### PR TITLE
add address for debugging

### DIFF
--- a/src/iridisalpha.asm
+++ b/src/iridisalpha.asm
@@ -1166,6 +1166,8 @@ srcOfProceduralBytes   =*+$01
 .include "graphics/sprites.asm"
 
 difficultySelected   =*+$01
+
+*=$4000
 ;-------------------------------------------------------
 ; MainControlLoop
 ; Execution starts here


### PR DESCRIPTION
This change adds the address $4000 to the MainControlLoop routine. This is the intended location for the routine, but is currently implied by the length of sprite and character data.

The C64Studio IDE allows source code debugging. With this change a breakpoint can reliably be set.